### PR TITLE
cd: backend deploy to ghcr

### DIFF
--- a/.github/workflows/publish-backend.yml
+++ b/.github/workflows/publish-backend.yml
@@ -1,6 +1,5 @@
 name: Create and publish Titanic backend image
 
-# Configures this workflow to run every time a change is pushed to the branch called `release`.
 on:
   push:
     branches: ['main']


### PR DESCRIPTION
deploys backend on push to github container registry. will be used for continuous deployment on backend