### PR TITLE
fix(backend): stream uploads direct-to-disk, surface 408, raise body timeout

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -348,6 +348,11 @@ async def upload_video():
         else:
             logger.debug("No folder specified for upload")
 
+        # TODO: enqueue race — if ffmpeg enqueues but umbrel raises (e.g. transient
+        # Redis), the except path deletes filepath while an ffmpeg job still references
+        # it. Fix is to reorder: do all fallible work (Firebase exchange) before the
+        # rename, then treat the enqueue pair as the commit point with best-effort
+        # cancel of ffmpeg_job on umbrel failure. See PR #235 review thread.
         if should_compress:
             ffmpeg_job = ffmpeg_queue.enqueue(compress_video, args=[filepath], result_ttl=86400)
             # Store user context instead of raw tokens to avoid expiration issues

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,14 +1,18 @@
 import asyncio
+import tempfile
 
 import requests
 from hypercorn.config import Config
 from hypercorn.asyncio import serve
 from quart import Quart, request, jsonify
+from quart.wrappers import Request
+from quart.formparser import FormDataParser
 from quart_cors import cors
 from redis import Redis
 from rq import Queue
 import os
 from quart import abort
+from werkzeug.exceptions import RequestTimeout
 from werkzeug.utils import secure_filename
 import logging
 from jobs.job import compress_video, upload_video_to_umbrel
@@ -17,7 +21,6 @@ from firebase_admin import credentials, auth, app_check
 from functools import wraps
 
 import jwt
-import aiofiles
 import sentry_sdk
 from sentry_sdk.integrations.quart import QuartIntegration
 
@@ -91,7 +94,7 @@ app.config['UNCOMPRESSED_FOLDER'] = UNCOMPRESSED_FOLDER
 app.config['COMPRESSED_FOLDER'] = COMPRESSED_FOLDER
 app.config['MAX_CONTENT_LENGTH'] = 20 * 1024 * 1024 * 1024  # 20GB max file size
 app.config['MAX_FORM_MEMORY_SIZE'] = 1 * 1024 * 1024  # Only keep 1MB in memory, rest goes to temp file
-app.config['BODY_TIMEOUT'] = 3600  # 1 hour timeout for large uploads
+app.config['BODY_TIMEOUT'] = 6 * 3600  # 6 hours — accommodates 20GB on slow residential uplinks
 
 # Ensure upload directories exist
 try:
@@ -106,6 +109,38 @@ except PermissionError as e:
     if not os.path.exists(COMPRESSED_FOLDER) or not os.access(COMPRESSED_FOLDER, os.W_OK):
         logger.error(f"Compressed directory {COMPRESSED_FOLDER} is not accessible")
         raise
+
+def _cleanup_upload_artifacts(part_path, filepath):
+    for path in (part_path, filepath):
+        if not path:
+            continue
+        try:
+            os.remove(path)
+            logger.debug(f"Cleaned up upload artifact: {path}")
+        except OSError:
+            pass
+
+
+def _upload_stream_factory(total_content_length, content_type, filename, content_length=None):
+    # Write the upload directly to UNCOMPRESSED_FOLDER so the post-parse step is an
+    # O(1) os.replace rather than a 20GB copy across filesystems.
+    return tempfile.NamedTemporaryFile(
+        dir=UNCOMPRESSED_FOLDER, delete=False, prefix='upload_', suffix='.part'
+    )
+
+
+class _StreamingRequest(Request):
+    def make_form_data_parser(self) -> FormDataParser:
+        return self.form_data_parser_class(
+            max_content_length=self.max_content_length,
+            max_form_memory_size=self.max_form_memory_size,
+            max_form_parts=self.max_form_parts,
+            cls=self.parameter_storage_class,
+            stream_factory=_upload_stream_factory,
+        )
+
+
+app.request_class = _StreamingRequest
 
 ffmpeg_queue = Queue('ffmpeg', connection=Redis(), default_timeout=19800) # 5.5 hours
 umbrel_queue = Queue('umbrel', connection=Redis(), default_timeout=7200) # 2 hours
@@ -172,82 +207,64 @@ def is_safe_path(filepath):
 async def upload_video():
     """
     Quart-native async file upload handler.
-    Uses await request.files and await file.read() for true streaming - no buffering!
-    Based on: https://stackoverflow.com/questions/59135171/uploading-files-to-a-quart-based-server
+    The body is streamed directly to UNCOMPRESSED_FOLDER by _upload_stream_factory,
+    so the only post-parse work is an os.replace to the final filename.
     """
+    part_path = None
+    filepath = None
     try:
         logger.debug(f"Received upload request from user: {request.user.get('email', 'unknown')}")
-        
-        # Get form data asynchronously - Quart streams this without buffering
+
+        # Get form data asynchronously - Quart streams the file body straight to disk
+        # via _upload_stream_factory, so no extra buffering happens here.
         form = await request.form
         files = await request.files
-        
+
         # Extract form fields
         should_compress = form.get('shouldCompress', 'true').lower() == 'true'
         folder = form.get('folder', '').strip() or None
-        
+
         # Get uploaded file
         file = files.get('file')
         if not file:
             logger.error("No file part in request")
             return jsonify({'error': 'No file part'}), 400
-        
+
         if not file.filename or file.filename == '':
             logger.error("Empty filename")
             return jsonify({'error': 'No selected file'}), 400
-        
+
+        # Path of the on-disk .part file written by _upload_stream_factory
+        part_path = getattr(file.stream, 'name', None)
+
         logger.debug(f"Received file: {file.filename}, compression: {should_compress}, folder: {folder}")
-        
+
         if not allowed_file(file.filename):
             return jsonify({'error': 'Invalid file type'}), 400
-        
+
         # Secure the filename
         filename = secure_filename(file.filename)
         filename = filename.replace("_", " ")  # undo stupid whitespace -> _ replacement
         target_dir = app.config['UNCOMPRESSED_FOLDER']
         filepath = os.path.join(target_dir, filename)
-        
+
         # Additional security check
         if not is_safe_path(filepath):
             logger.error(f"Invalid file path: {filepath}")
             return jsonify({'error': 'Invalid file path'}), 400
-        
+
         # Create unique filename to prevent overwriting
         base, ext = os.path.splitext(filename)
         counter = 1
         while os.path.exists(filepath):
             filepath = os.path.join(target_dir, f"{base}_{counter}{ext}")
             counter += 1
-        
-        logger.debug(f"Streaming file to disk: {filepath}")
-        
-        # Stream file to disk in chunks using async I/O to prevent blocking the event loop
-        # Using 8MB chunks for better performance with large files (per best practices)
-        chunk_size = 8 * 1024 * 1024  # 8MB chunks - optimal for large files
-        bytes_written = 0
-        
-        # Use aiofiles for non-blocking async file operations
-        async with aiofiles.open(filepath, 'wb') as f:
-            while True:
-                # Read chunk synchronously from Quart's temp file
-                # Note: file.read() is sync but Quart has already streamed to temp disk
-                chunk = file.read(chunk_size)
-                if not chunk:
-                    break
-                # Write asynchronously to prevent blocking event loop
-                await f.write(chunk)
-                bytes_written += len(chunk)
-                
-                # Log progress every 500MB
-                if bytes_written % (500 * 1024 * 1024) < chunk_size:
-                    logger.debug(f"Written {bytes_written / (1024*1024):.1f} MB")
-        
-        logger.debug(f"File saved successfully: {bytes_written / (1024*1024):.1f} MB total")
-        
-        # Close Quart's temp file handle
-        # No need for try/except - if file doesn't exist, we wouldn't have reached here
+
+        # Close the temp file handle, then rename it into place — same fs, O(1).
         file.close()
-        logger.debug("Temp file handle closed")
+        os.replace(part_path, filepath)
+        part_path = None
+        logger.debug(f"File saved: {filepath}")
         
         # Enqueue the video processing job only if compression is enabled
         # Store user UID instead of raw Firebase ID token
@@ -297,15 +314,15 @@ async def upload_video():
             'filename': os.path.basename(filepath)
         }), 200
         
+    except RequestTimeout:
+        # Body didn't arrive within BODY_TIMEOUT — surface 408 instead of swallowing
+        # it into a generic 500 so the frontend can show a meaningful message.
+        logger.warning("Upload aborted: client did not finish body within BODY_TIMEOUT")
+        _cleanup_upload_artifacts(part_path, filepath)
+        return jsonify({'error': 'Upload timed out — connection too slow to finish within the server window'}), 408
     except Exception as e:
         logger.error(f"Unexpected error: {str(e)}")
-        # Clean up file if it exists
-        if 'filepath' in locals() and os.path.exists(filepath):
-            try:
-                os.remove(filepath)
-                logger.debug(f"Cleaned up file after error: {filepath}")
-            except:
-                pass
+        _cleanup_upload_artifacts(part_path, filepath)
         return jsonify({'error': f'Unexpected error: {str(e)}'}), 500
 
 @app.route('/api/health')

--- a/backend/app.py
+++ b/backend/app.py
@@ -291,7 +291,9 @@ async def upload_video():
         counter = 0
         while True:
             try:
-                fd = os.open(candidate, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+                # No mode arg: os.replace below swaps in the .part file's inode
+                # (NamedTemporaryFile default 0o600), so the placeholder mode is moot.
+                fd = os.open(candidate, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
                 os.close(fd)
                 break
             except FileExistsError:

--- a/backend/app.py
+++ b/backend/app.py
@@ -4,7 +4,7 @@ import tempfile
 import requests
 from hypercorn.config import Config
 from hypercorn.asyncio import serve
-from quart import Quart, request, jsonify
+from quart import Quart, request, jsonify, g
 from quart.wrappers import Request
 from quart.formparser import FormDataParser
 from quart_cors import cors
@@ -110,23 +110,46 @@ except PermissionError as e:
         logger.error(f"Compressed directory {COMPRESSED_FOLDER} is not accessible")
         raise
 
-def _cleanup_upload_artifacts(part_path, filepath):
-    for path in (part_path, filepath):
-        if not path:
-            continue
-        try:
-            os.remove(path)
-            logger.debug(f"Cleaned up upload artifact: {path}")
-        except OSError:
-            pass
+def _remove_quietly(path):
+    try:
+        os.remove(path)
+        logger.debug(f"Cleaned up upload artifact: {path}")
+    except FileNotFoundError:
+        pass
+    except OSError as e:
+        # Permissions, busy handles, etc. — surface so disk leaks don't go unnoticed.
+        logger.warning(f"Failed to remove upload artifact {path}: {e}")
+
+
+def _cleanup_upload_artifacts():
+    """Remove any .part files this request created plus the final filepath if set.
+
+    Pulled from `g` so that uploads which fail *before* the handler captures the temp
+    path (e.g. RequestTimeout inside `await request.form`) still get cleaned up.
+    """
+    for path in getattr(g, '_upload_parts', ()):
+        _remove_quietly(path)
+    g._upload_parts = []
+    final_path = getattr(g, '_upload_final_path', None)
+    if final_path:
+        _remove_quietly(final_path)
+        g._upload_final_path = None
 
 
 def _upload_stream_factory(total_content_length, content_type, filename, content_length=None):
     # Write the upload directly to UNCOMPRESSED_FOLDER so the post-parse step is an
     # O(1) os.replace rather than a 20GB copy across filesystems.
-    return tempfile.NamedTemporaryFile(
+    f = tempfile.NamedTemporaryFile(
         dir=UNCOMPRESSED_FOLDER, delete=False, prefix='upload_', suffix='.part'
     )
+    # Register the path in request-local state so cleanup can find it even if
+    # parsing aborts before the handler captures `file.stream.name`.
+    parts = getattr(g, '_upload_parts', None)
+    if parts is None:
+        parts = []
+        g._upload_parts = parts
+    parts.append(f.name)
+    return f
 
 
 class _StreamingRequest(Request):
@@ -141,6 +164,14 @@ class _StreamingRequest(Request):
 
 
 app.request_class = _StreamingRequest
+
+
+@app.teardown_request
+async def _teardown_upload_cleanup(_exc):
+    # Safety net: any .part files registered by _upload_stream_factory that the handler
+    # didn't consume (early return, parse-time exception, etc.) get removed here.
+    if getattr(g, '_upload_parts', None) or getattr(g, '_upload_final_path', None):
+        _cleanup_upload_artifacts()
 
 ffmpeg_queue = Queue('ffmpeg', connection=Redis(), default_timeout=19800) # 5.5 hours
 umbrel_queue = Queue('umbrel', connection=Redis(), default_timeout=7200) # 2 hours
@@ -210,13 +241,13 @@ async def upload_video():
     The body is streamed directly to UNCOMPRESSED_FOLDER by _upload_stream_factory,
     so the only post-parse work is an os.replace to the final filename.
     """
-    part_path = None
-    filepath = None
     try:
         logger.debug(f"Received upload request from user: {request.user.get('email', 'unknown')}")
 
         # Get form data asynchronously - Quart streams the file body straight to disk
         # via _upload_stream_factory, so no extra buffering happens here.
+        # NOTE: 6h BODY_TIMEOUT means a single slow upload occupies a Hypercorn worker
+        # for that long. Fine at current traffic; revisit if upload concurrency grows.
         form = await request.form
         files = await request.files
 
@@ -234,8 +265,9 @@ async def upload_video():
             logger.error("Empty filename")
             return jsonify({'error': 'No selected file'}), 400
 
-        # Path of the on-disk .part file written by _upload_stream_factory
-        part_path = getattr(file.stream, 'name', None)
+        # `file.stream` is the NamedTemporaryFile returned by _upload_stream_factory,
+        # so `.name` is the on-disk .part path we registered in `g._upload_parts`.
+        part_path = file.stream.name
 
         logger.debug(f"Received file: {file.filename}, compression: {should_compress}, folder: {folder}")
 
@@ -246,24 +278,37 @@ async def upload_video():
         filename = secure_filename(file.filename)
         filename = filename.replace("_", " ")  # undo stupid whitespace -> _ replacement
         target_dir = app.config['UNCOMPRESSED_FOLDER']
-        filepath = os.path.join(target_dir, filename)
+        base, ext = os.path.splitext(filename)
+        candidate = os.path.join(target_dir, filename)
 
         # Additional security check
-        if not is_safe_path(filepath):
-            logger.error(f"Invalid file path: {filepath}")
+        if not is_safe_path(candidate):
+            logger.error(f"Invalid file path: {candidate}")
             return jsonify({'error': 'Invalid file path'}), 400
 
-        # Create unique filename to prevent overwriting
-        base, ext = os.path.splitext(filename)
-        counter = 1
-        while os.path.exists(filepath):
-            filepath = os.path.join(target_dir, f"{base}_{counter}{ext}")
-            counter += 1
+        # Atomically claim a unique filename via O_EXCL — avoids the TOCTOU race where
+        # two concurrent uploads with the same filename pick the same target.
+        counter = 0
+        while True:
+            try:
+                fd = os.open(candidate, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+                os.close(fd)
+                break
+            except FileExistsError:
+                counter += 1
+                candidate = os.path.join(target_dir, f"{base}_{counter}{ext}")
+                if not is_safe_path(candidate):
+                    return jsonify({'error': 'Invalid file path'}), 400
+
+        filepath = candidate
+        g._upload_final_path = filepath
 
         # Close the temp file handle, then rename it into place — same fs, O(1).
+        # os.replace clobbers the 0-byte placeholder we just created with O_EXCL.
         file.close()
         os.replace(part_path, filepath)
-        part_path = None
+        # Drop the renamed .part from the tracked list so cleanup won't try again.
+        g._upload_parts = [p for p in getattr(g, '_upload_parts', ()) if p != part_path]
         logger.debug(f"File saved: {filepath}")
         
         # Enqueue the video processing job only if compression is enabled
@@ -309,20 +354,22 @@ async def upload_video():
             # If compression is disabled, just upload the original file
             umbrel_job = umbrel_queue.enqueue(upload_video_to_umbrel, args=[filepath], meta=job_meta)
         
+        # Job successfully enqueued — handler owns the file no longer; don't clean up.
+        g._upload_final_path = None
         return jsonify({
             'message': 'File uploaded successfully',
             'filename': os.path.basename(filepath)
         }), 200
-        
+
     except RequestTimeout:
         # Body didn't arrive within BODY_TIMEOUT — surface 408 instead of swallowing
         # it into a generic 500 so the frontend can show a meaningful message.
         logger.warning("Upload aborted: client did not finish body within BODY_TIMEOUT")
-        _cleanup_upload_artifacts(part_path, filepath)
+        _cleanup_upload_artifacts()
         return jsonify({'error': 'Upload timed out — connection too slow to finish within the server window'}), 408
     except Exception as e:
         logger.error(f"Unexpected error: {str(e)}")
-        _cleanup_upload_artifacts(part_path, filepath)
+        _cleanup_upload_artifacts()
         return jsonify({'error': f'Unexpected error: {str(e)}'}), 500
 
 @app.route('/api/health')

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -46,7 +46,6 @@ pyparsing==3.3.2
 Quart==0.20.0
 quart-cors==0.8.0
 sentry-sdk[quart,rq]==2.58.0
-aiofiles==25.1.0
 redis==7.4.0
 requests==2.33.1
 requests-toolbelt==1.0.0


### PR DESCRIPTION
## Summary

Fixes [TITANIC-QUART-A](https://ivan-g0.sentry.io/issues/TITANIC-QUART-A) — a 20GB upload hit `BODY_TIMEOUT` (3600s) exactly and surfaced as a generic 500 (`Unexpected error: 408 Request Timeout: ...`).

- **Streaming direct-to-disk:** new `_upload_stream_factory` writes the multipart file straight into `UNCOMPRESSED_FOLDER` as `upload_*.part`; the post-parse step is now `os.replace` to the final filename — O(1) on the same filesystem instead of a 20GB read+write copy. Halves peak disk usage during an upload from ~40GB to ~20GB.
- **Proper 408 surfacing:** catch `werkzeug.exceptions.RequestTimeout` and return a 408 with a meaningful body, instead of letting the catch-all swallow it into a 500. Frontend can now show "your upload was too slow" instead of a generic error.
- **`BODY_TIMEOUT` 1h → 6h:** matches the recently-bumped 20GB ceiling. At ~1 MB/s residential uplink, 20GB takes ~6 hours; the old 1h was the immediate cause of TITANIC-QUART-A.

Drops `aiofiles` dependency — no longer used after removing the chunk-loop re-stream.

### Why now

In the trace for the Sentry issue, the `http.server` span lasted exactly **3,601,128ms** — `BODY_TIMEOUT` to the millisecond. The recently-raised 20GB upload ceiling silently outran the 1h body timeout for slower clients.

### Implementation notes

- Subclasses `quart.wrappers.Request` to thread our `stream_factory` through `make_form_data_parser` (Quart's default `make_form_data_parser` doesn't pass `stream_factory` even though `FormDataParser` accepts it).
- `_cleanup_upload_artifacts` handles both partial-upload (`.part` exists, never renamed) and post-rename failure (firebase token exchange fails after the file is already at `filepath`) cases.
- `.part` files live in `UNCOMPRESSED_FOLDER` during upload. Verified no other code path globs/listdirs that folder — files are referenced by absolute path through RQ — so partials don't leak into worker processing.

## Test plan

- [ ] Upload a small file end-to-end in dev (verify happy path: file lands at correct path, job enqueued)
- [ ] Upload a larger file (>1GB) and confirm only one copy on disk during upload (no double-buffer in `/tmp`)
- [ ] Force a slow upload past `BODY_TIMEOUT` (e.g. via `tc` traffic shaping) and confirm 408 response with the new error message
- [ ] Kill an upload mid-stream and confirm the `.part` file is cleaned up (check `UNCOMPRESSED_FOLDER` has no orphans)
- [ ] Trigger a post-rename failure path (e.g. break Firebase token exchange in dev) and confirm the orphan at `filepath` is cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)