### PR TITLE
fix(functions): pin jose to v5 to fix firebase-admin 14 deploy

### DIFF
--- a/frontend/functions/bun.lock
+++ b/frontend/functions/bun.lock
@@ -20,6 +20,9 @@
       },
     },
   },
+  "overrides": {
+    "jose": "^5.10.0",
+  },
   "packages": {
     "@ampproject/remapping": ["@ampproject/remapping@2.3.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw=="],
 
@@ -845,7 +848,7 @@
 
     "jest-worker": ["jest-worker@29.7.0", "", { "dependencies": { "@types/node": "*", "jest-util": "^29.7.0", "merge-stream": "^2.0.0", "supports-color": "^8.0.0" } }, "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw=="],
 
-    "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
+    "jose": ["jose@5.10.0", "", {}, "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 

--- a/frontend/functions/package.json
+++ b/frontend/functions/package.json
@@ -20,6 +20,9 @@
     "firebase-admin": "^14.0.0",
     "firebase-functions": "^7.2.5"
   },
+  "overrides": {
+    "jose": "^5.10.0"
+  },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.61.1",
     "@typescript-eslint/parser": "^8.61.1",


### PR DESCRIPTION
## Summary
PR #269 (firebase-admin 13→14) broke **CD - Firebase Functions** on main with `ERR_REQUIRE_ESM`.

firebase-admin 14 pulls `jwks-rsa@4`, which depends on `jose@^6` (ESM-only). The CommonJS functions `require()` it during the deploy action's "Loading and analyzing source code" step, which runs on a Node version that does not allow `require()` of ESM — hence the failure. (CI's `functions-build` only runs `tsc`, so it never caught this.)

`jwks-rsa@4` only uses `importJWK`, `exportSPKI`, `decodeJwt`, `decodeProtectedHeader` — all present in jose v5, which ships a CommonJS build. So this overrides `jose` to `^5.10.0`.

## Verification (local)
- Reproduced the exact `ERR_REQUIRE_ESM` with `NODE_OPTIONS=--no-experimental-require-module` (mimics the deploy env).
- After the override: `bun install --frozen-lockfile` clean, `bun run build` (tsc) passes, and loading the built `lib/index.js` with `require(esm)` disabled succeeds.

## Test plan
- [ ] CI green on this PR
- [ ] After merge, **CD - Firebase Functions** on main goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)