### PR TITLE
fix(security): clear all 10 open security alerts

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -9,6 +9,11 @@ on:
     paths:
       - 'frontend/**'
       - '.github/workflows/firebase-hosting-merge.yml'
+
+permissions:
+  contents: read
+  checks: write
+
 jobs:
   build_and_deploy_frontend:
     runs-on: ubuntu-latest

--- a/.github/workflows/functions-build.yml
+++ b/.github/workflows/functions-build.yml
@@ -6,6 +6,9 @@ on:
       - 'frontend/functions/**'
       - '.github/workflows/functions-build.yml'
 
+permissions:
+  contents: read
+
 jobs:
   build_functions:
     runs-on: ubuntu-latest

--- a/.github/workflows/functions-deploy.yml
+++ b/.github/workflows/functions-deploy.yml
@@ -6,6 +6,10 @@ on:
     paths:
       - 'frontend/functions/**'
       - '.github/workflows/functions-deploy.yml'
+
+permissions:
+  contents: read
+
 jobs:
   build_and_deploy_functions:
     runs-on: ubuntu-latest

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,7 +7,7 @@ certifi==2026.5.20
 cffi==2.0.0
 charset-normalizer==3.4.7
 click==8.4.1
-cryptography==48.0.0
+cryptography==48.0.1
 ffmpeg-python==0.2.0
 firebase-admin==7.4.0
 future==1.0.0
@@ -32,7 +32,7 @@ idna==3.18
 itsdangerous==2.2.0
 Jinja2==3.1.6
 MarkupSafe==3.0.3
-msgpack==1.1.2
+msgpack==1.2.1
 priority==2.0.0
 proto-plus==1.28.0
 protobuf==7.35.1

--- a/titanic/Cargo.lock
+++ b/titanic/Cargo.lock
@@ -203,9 +203,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.15.1"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b5ce75405893cd713f9ab8e297d8e438f624dde7d706108285f7e17a25a180f"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -214,9 +214,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.34.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "179c3777a8b5e70e90ea426114ffc565b2c1a9f82f6c4a0c5a34aa6ef5e781b6"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",


### PR DESCRIPTION
Drives the **Security & quality** tab from 10 open alerts to **0**.

## Dependabot (7 → 0)
| Alert | Package | Change | Fixes |
|---|---|---|---|
| 5× high | `aws-lc-sys` (rust, transitive) | `aws-lc-rs` 1.15.1→1.17.0 ⇒ `aws-lc-sys` 0.34.0→**0.41.0** | GHSA-9f94-5g5w-gf6r, GHSA-394x-vwmw-crm3, GHSA-hfpc-8r3f-gw53, GHSA-65p9-r9h6-22vj, GHSA-vw5v-4f2q-w9xf |
| high | `cryptography` (pip) | 48.0.0→**48.0.1** | GHSA-537c-gmf6-5ccf (bundled OpenSSL) |
| high | `msgpack` (pip) | 1.1.2→**1.2.1** | GHSA-6v7p-g79w-8964 (OOB read on Unpacker reuse) |

- The 5 rust alerts are one root cause: `aws-lc-rs` capped `aws-lc-sys` at `^0.34`, so the parent was bumped to pull the patched `-sys`. **Lockfile-only — `Cargo.toml` untouched**, and `cargo build` passes locally.

## CodeQL — `actions/missing-workflow-permissions` (3 → 0)
Added minimal top-level `GITHUB_TOKEN` permissions:
- `functions-build.yml`, `functions-deploy.yml` → `contents: read` (deploy auths via `FIREBASE_TOKEN` secret, not the workflow token)
- `firebase-hosting-merge.yml` → `contents: read` + `checks: write` (the hosting action uses `repoToken` to write check runs)

## Note
This makes the existing Dependabot PRs **#273** (cryptography) and **#278** (msgpack) redundant — close them after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)