### PR TITLE
security: lock down LAN exposure, Redis auth, and dev auth bypass

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,7 +2,16 @@ GITHUB_USERNAME=
 GITHUB_PAT=
 # the above is used on the vps itself to handle private ghcr
 IS_DEV=
+# Disables Firebase token + App Check verification. Local dev ONLY — requires
+# IS_DEV=true as well, and must never be set in production.
+DEV_AUTH_BYPASS=
+# Overrides the hypercorn bind (default 127.0.0.1:5000). Set to 0.0.0.0:5000 when
+# running behind a Docker bridge with a published port; leave unset in prod (host
+# networking + Caddy in front).
+HYPERCORN_BIND=
 UMBREL_SERVER_URL=
+# Redis auth (queue holds refresh tokens). generate with: openssl rand -hex 32
+REDIS_PASSWORD=
 SENTRY_ENVELOPE_URL=
 FIREBASE_API_KEY=
 ENABLE_RNNOISE=

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -75,8 +75,9 @@ ENV PATH=/usr/local/bin:$PATH
 # Switch to non-root user
 USER flask
 
-# Expose ports
-EXPOSE 5000 6379
+# Expose the HTTP port only. Redis (6379) is loopback-only and must not be
+# advertised or published off-host.
+EXPOSE 5000
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \

--- a/backend/app.py
+++ b/backend/app.py
@@ -21,12 +21,24 @@ from rq import Queue
 from sentry_sdk.integrations.quart import QuartIntegration
 from werkzeug.exceptions import RequestTimeout
 
-from fileutils import remove_quietly, sanitize_path_component
+from fileutils import remove_quietly, sanitize_path_component, scrub_event
 from jobs.job import compress_video, upload_video_to_umbrel
 
 IS_DEV = os.environ.get("IS_DEV", "false").lower() == "true"
+# Disabling authentication is deliberately its OWN flag, not a side effect of
+# IS_DEV. IS_DEV toggles convenience only (debug logs, localhost CORS); flipping
+# it in a prod image must never silently drop auth. The bypass also requires
+# IS_DEV so it can't be turned on by itself in a production environment.
+DEV_AUTH_BYPASS = (
+    IS_DEV and os.environ.get("DEV_AUTH_BYPASS", "false").lower() == "true"
+)
 logging.basicConfig(level=logging.DEBUG if IS_DEV else logging.INFO)
 logger = logging.getLogger(__name__)
+if DEV_AUTH_BYPASS:
+    logger.warning(
+        "DEV_AUTH_BYPASS is ON — Firebase token and App Check verification are "
+        "DISABLED. This must never be set in production."
+    )
 app = Quart(__name__)
 origins = ["https://titanic.ivan.boston"]
 
@@ -51,6 +63,7 @@ if _sentry_dsn:
         environment=os.environ.get("SENTRY_ENVIRONMENT"),
         integrations=[QuartIntegration()],
         send_default_pii=True,
+        before_send=scrub_event,
         traces_sample_rate=_sentry_traces_sample_rate(),
     )
 
@@ -209,18 +222,19 @@ async def _teardown_upload_cleanup(_exc):
         _cleanup_upload_artifacts()
 
 
+_redis = Redis(password=os.environ.get("REDIS_PASSWORD") or None)  # matches start.sh --requirepass
 ffmpeg_queue = Queue(
-    "ffmpeg", connection=Redis(), default_timeout=86400
+    "ffmpeg", connection=_redis, default_timeout=86400
 )  # 24 hours, probably really bad :(
-umbrel_queue = Queue("umbrel", connection=Redis(), default_timeout=7200)  # 2 hours
+umbrel_queue = Queue("umbrel", connection=_redis, default_timeout=7200)  # 2 hours
 
 
 # TODO: set Firebase hosting IP to be static, so I can whitelist it in the backend??? 🤔
 def verify_firebase_token(f):
     @wraps(f)
     async def decorated_function(*args, **kwargs):
-        if IS_DEV:
-            # When in development mode, we bypass token verification and mock the user.
+        if DEV_AUTH_BYPASS:
+            # Local-only escape hatch: bypass token verification and mock the user.
             request.user = {"email": "dev@example.com", "uid": "dev-user"}
             return await f(*args, **kwargs)
 
@@ -244,8 +258,9 @@ def verify_firebase_token(f):
 
 @app.before_request
 async def verify_app_check() -> None:
-    # no AppCheck for OPTIONS requests (CORS preflight), health endpoint, or dev mode
-    if IS_DEV or request.method == "OPTIONS" or request.path == "/health":
+    # no AppCheck for OPTIONS requests (CORS preflight), health endpoint, or when
+    # the local dev auth bypass is explicitly enabled
+    if DEV_AUTH_BYPASS or request.method == "OPTIONS" or request.path == "/health":
         return
 
     app_check_token = request.headers.get("X-Firebase-AppCheck", default="")
@@ -617,4 +632,12 @@ async def docker_health_check():
 
 
 if __name__ == "__main__":
-    asyncio.run(serve(app, Config.from_toml("hypercorn.toml")))
+    hypercorn_config = Config.from_toml("hypercorn.toml")
+    # Dev/test run behind a Docker bridge with a published port, which forwards to
+    # the container's external interface — so they set HYPERCORN_BIND=0.0.0.0:5000.
+    # Prod leaves this unset and keeps the loopback bind from the toml.
+    bind_override = os.environ.get("HYPERCORN_BIND")
+    if bind_override:
+        hypercorn_config.bind = [bind_override]
+        hypercorn_config.quic_bind = [bind_override]
+    asyncio.run(serve(app, hypercorn_config))

--- a/backend/docker-compose.run.yml
+++ b/backend/docker-compose.run.yml
@@ -10,6 +10,7 @@ services:
       - GOOGLE_APPLICATION_CREDENTIALS=/run/secrets/admin-sdk-cred
       - UMBREL_SERVER_URL=http://umbrel:3029 # tailsale ip
       - FIREBASE_API_KEY=${FIREBASE_API_KEY}
+      - REDIS_PASSWORD=${REDIS_PASSWORD}
       - SENTRY_ENVIRONMENT=${SENTRY_ENVIRONMENT:-production}
       - SENTRY_DSN=${SENTRY_QUART_DSN}
       - SENTRY_RQ_DSN=${SENTRY_RQ_DSN}

--- a/backend/fileutils.py
+++ b/backend/fileutils.py
@@ -4,6 +4,49 @@ import unicodedata
 
 logger = logging.getLogger(__name__)
 
+# Keys whose values must never leave the process in a Sentry event. Matched
+# case-insensitively against dict keys anywhere in the event tree. "refresh_token"
+# is the important one: it lives in RQ job meta and is a long-lived Firebase
+# credential the RQ integration would otherwise ship to Sentry on a job failure.
+_SENSITIVE_KEYS = frozenset(
+    {
+        "refresh_token",
+        "authorization",
+        "x-firebase-appcheck",
+        "id_token",
+        "custom_token",
+        "token",
+        "password",
+        "api_key",
+        "firebase_api_key",
+    }
+)
+_REDACTED = "[redacted]"
+
+
+def _scrub(value):
+    if isinstance(value, dict):
+        return {
+            k: (_REDACTED if isinstance(k, str) and k.lower() in _SENSITIVE_KEYS else _scrub(v))
+            for k, v in value.items()
+        }
+    if isinstance(value, (list, tuple)):
+        return type(value)(_scrub(v) for v in value)
+    return value
+
+
+def scrub_event(event, _hint=None):
+    """Sentry `before_send` hook: redact sensitive values before events are sent.
+
+    Walks the whole event tree and blanks any value under a sensitive key. Never
+    raises — a throwing before_send would silently drop the event, so on any error
+    we return the event unchanged rather than lose observability.
+    """
+    try:
+        return _scrub(event)
+    except Exception:  # pragma: no cover - defensive
+        return event
+
 # Max bytes for a single path component. Linux NAME_MAX is 255 bytes on the
 # common filesystems; a longer name fails with ENAMETOOLONG.
 MAX_PATH_COMPONENT_BYTES = 255

--- a/backend/hypercorn.toml
+++ b/backend/hypercorn.toml
@@ -1,5 +1,8 @@
-bind = ["0.0.0.0:5000"]
-quic_bind = ["0.0.0.0:5000"]
+# Loopback by default: in prod the container uses host networking and Caddy is the
+# only thing that should face the internet (it reverse-proxies to localhost:5000).
+# Dev/test publish the port over a Docker bridge and override this via HYPERCORN_BIND.
+bind = ["127.0.0.1:5000"]
+quic_bind = ["127.0.0.1:5000"]
 wsgi_max_body_size = 21474836480 # 20 gigs in bytes
 keep_alive_timeout = 5  # Close idle connections after 5s to prevent blocking
 worker_class = "asyncio"  # Ensure async worker for better concurrency

--- a/backend/redis.conf
+++ b/backend/redis.conf
@@ -8,11 +8,14 @@ appendfsync everysec
 # Minimal RDB save configuration to reduce disk I/O
 save 3600 1
 
-# Disable protected mode for container usage
-protected-mode no
+# Keep protected mode on; Redis is only ever reached by the app/workers that
+# share this container's network namespace (loopback), never from outside.
+protected-mode yes
 
-# Bind to all interfaces for container networking
-bind 0.0.0.0
+# Bind to loopback only. The queue holds Firebase refresh tokens in job meta, so
+# it must never be reachable off-host — the prod container runs with host
+# networking, where bind 0.0.0.0 would expose 6379 on the VPS's public interface.
+bind 127.0.0.1
 
 # Set maximum memory (optional, adjust as needed)
 # maxmemory 256mb

--- a/backend/start.sh
+++ b/backend/start.sh
@@ -10,7 +10,13 @@ cleanup() {
 
 trap cleanup TERM INT
 
-redis-server redis.conf &
+# CLI arg, not redis.conf, so the image stays secret-free; the queue holds Firebase refresh tokens
+if [ -n "$REDIS_PASSWORD" ]; then
+    redis-server redis.conf --requirepass "$REDIS_PASSWORD" &
+else
+    echo "WARNING: REDIS_PASSWORD is not set — Redis is running without auth" >&2
+    redis-server redis.conf &
+fi
 redis_pid=$!
 
 python worker.py ffmpeg &

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -6,6 +6,8 @@ from sentry_sdk.integrations.rq import RqIntegration
 from redis import Redis
 from rq import Worker, Queue
 
+from fileutils import scrub_event
+
 logging.basicConfig(
     level=logging.DEBUG if os.environ.get('IS_DEV', 'false').lower() == 'true' else logging.INFO,
     format='%(asctime)s - %(process)d - %(name)s - %(levelname)s - %(message)s'
@@ -27,11 +29,12 @@ if dsn:
         environment=os.environ.get("SENTRY_ENVIRONMENT"),
         integrations=[RqIntegration()],
         send_default_pii=True,
+        before_send=scrub_event,
         traces_sample_rate=traces_sample_rate,
     )
 
 if __name__ == "__main__":
     queues = sys.argv[1:] or ["default"]
-    conn = Redis()
+    conn = Redis(password=os.environ.get("REDIS_PASSWORD") or None)  # matches start.sh --requirepass
     worker = Worker([Queue(q, connection=conn) for q in queues], connection=conn)
     worker.work()

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -22,6 +22,10 @@ services:
       - PYTHONUNBUFFERED=1
       - GOOGLE_APPLICATION_CREDENTIALS=/run/secrets/admin-sdk-cred
       - IS_DEV=${IS_DEV:-true}
+      # Local-only: explicitly disable auth for the dev stack.
+      - DEV_AUTH_BYPASS=${DEV_AUTH_BYPASS:-true}
+      # Published over the Docker bridge (6969:5000), so bind all interfaces.
+      - HYPERCORN_BIND=0.0.0.0:5000
       - UMBREL_SERVER_URL=http://umbrel:3029
       - FIREBASE_API_KEY=${FIREBASE_API_KEY}
       - SENTRY_ENVIRONMENT=${SENTRY_ENVIRONMENT:-dev}
@@ -56,6 +60,8 @@ services:
       - SENTRY_DSN=${RUST_SENTRY_DSN}
       - SENTRY_ENVIRONMENT=${SENTRY_ENVIRONMENT:-dev}
       - SENTRY_TRACES_SAMPLE_RATE=${SENTRY_TRACES_SAMPLE_RATE}
+      # Local-only: explicitly disable Firebase auth for the dev stack.
+      - DEV_AUTH_BYPASS=${DEV_AUTH_BYPASS:-true}
     volumes:
       # Mount source files for hot-reloading (cargo-watch will rebuild)
       - ./titanic/src:/app/src

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -13,6 +13,7 @@ services:
     environment:
       - FIREBASE_PROJECT_ID=test-project
       - IS_DEV=true
+      - DEV_AUTH_BYPASS=true
       - BIND_ADDRESS=0.0.0.0:3029
       - PLEX_MEDIA_PATH=/downloads
       - DATA_DIR=/data
@@ -39,6 +40,8 @@ services:
              python app.py"
     environment:
       - IS_DEV=true
+      - DEV_AUTH_BYPASS=true
+      - HYPERCORN_BIND=0.0.0.0:5000
       - PYTHONUNBUFFERED=1
       - UMBREL_SERVER_URL=http://umbrel:3029
     ports:

--- a/titanic/.env.example
+++ b/titanic/.env.example
@@ -3,6 +3,9 @@ FIREBASE_PROJECT_ID=id
 
 # Optional, if values not provided, defaults are used:
 IS_DEV=boolean # default: false
+# Disables Firebase auth. Local dev ONLY — requires IS_DEV=true as well, and must
+# never be set in production. default: false
+DEV_AUTH_BYPASS=boolean
 BIND_ADDRESS=0.0.0.0:3029 # bind address, default is 0.0.0.0:3029
 PLEX_MEDIA_PATH=/downloads # default: /downloads
 SENTRY_DNS=

--- a/titanic/docker-compose.yml
+++ b/titanic/docker-compose.yml
@@ -3,8 +3,9 @@ services:
     image: ghcr.io/onkr0d/titanic/titanic:latest@sha256:10d2bf3a1c6a3d83e0f84e71d74d160da190f947a28bc7de1fceb9125c0d8bd2
     user: "0:0"
     restart: unless-stopped
+    # tailnet-only bind (see exports.sh): the VPS needs this port, the LAN must not reach it
     ports:
-      - "${APP_TITANIC_PORT:-3029}:3029"
+      - "${APP_TITANIC_BIND_IP:-0.0.0.0}:${APP_TITANIC_PORT:-3029}:3029"
     environment:
       - RUST_LOG=info
       - IS_DEV=false

--- a/titanic/exports.sh
+++ b/titanic/exports.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# bind the published port to the tailnet only; 0.0.0.0 fallback keeps the app up if Tailscale is down
+APP_TITANIC_BIND_IP="$(ip -4 -o addr show tailscale0 2>/dev/null | awk '{print $4}' | cut -d/ -f1 | head -n 1)"
+export APP_TITANIC_BIND_IP="${APP_TITANIC_BIND_IP:-0.0.0.0}"

--- a/titanic/src/auth.rs
+++ b/titanic/src/auth.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::config::Config;
 
@@ -45,7 +45,7 @@ pub struct FirebaseAuth {
     project_id: String,
     client: Client,
     public_keys: Arc<RwLock<HashMap<String, String>>>,
-    is_dev: bool,
+    dev_auth_bypass: bool,
 }
 
 impl FirebaseAuth {
@@ -53,18 +53,25 @@ impl FirebaseAuth {
         let client = Client::new();
         let public_keys = Arc::new(RwLock::new(HashMap::new()));
 
+        if config.dev_auth_bypass {
+            warn!(
+                "DEV_AUTH_BYPASS is ON — Firebase token verification is DISABLED. \
+                 This must never be set in production."
+            );
+        }
+
         Ok(FirebaseAuth {
             project_id: config.firebase_project_id.clone(),
             client,
             public_keys,
-            is_dev: config.is_dev,
+            dev_auth_bypass: config.dev_auth_bypass,
         })
     }
 
     pub async fn verify_token(&self, headers: &HeaderMap) -> Result<FirebaseUser, AppError> {
-        // Bypass auth in development mode
-        if self.is_dev {
-            info!("DEV mode: Bypassing token verification");
+        // Bypass auth only when the explicit local dev bypass is enabled
+        if self.dev_auth_bypass {
+            info!("DEV_AUTH_BYPASS: Bypassing token verification");
             return Ok(FirebaseUser {
                 uid: "dev-user".to_string(),
                 email: "dev@example.com".to_string(),
@@ -230,7 +237,7 @@ mod tests {
             project_id: "test-project".into(),
             client: Client::new(),
             public_keys: Arc::new(RwLock::new(HashMap::new())),
-            is_dev: true,
+            dev_auth_bypass: true,
         }
     }
 
@@ -239,7 +246,7 @@ mod tests {
             project_id: "test-project".into(),
             client: Client::new(),
             public_keys: Arc::new(RwLock::new(HashMap::new())),
-            is_dev: false,
+            dev_auth_bypass: false,
         }
     }
 

--- a/titanic/src/config.rs
+++ b/titanic/src/config.rs
@@ -8,6 +8,10 @@ pub struct Config {
     pub firebase_project_id: String,
     pub plex_media_path: String,
     pub is_dev: bool,
+    /// Whether to bypass Firebase auth. Deliberately separate from `is_dev` so a
+    /// stray `IS_DEV=true` in production can't silently disable authentication;
+    /// requires both `IS_DEV=true` and an explicit `DEV_AUTH_BYPASS=true`.
+    pub dev_auth_bypass: bool,
     pub data_dir: String,
 }
 
@@ -32,6 +36,12 @@ impl Config {
             .to_lowercase()
             == "true";
 
+        let dev_auth_bypass = is_dev
+            && env::var("DEV_AUTH_BYPASS")
+                .unwrap_or_else(|_| "false".to_string())
+                .to_lowercase()
+                == "true";
+
         let data_dir = env::var("DATA_DIR").unwrap_or_else(|_| {
             if cfg!(target_os = "macos") {
                 "./data".to_string()
@@ -45,6 +55,7 @@ impl Config {
             firebase_project_id,
             plex_media_path,
             is_dev,
+            dev_auth_bypass,
             data_dir,
         })
     }

--- a/titanic/tests/integration.rs
+++ b/titanic/tests/integration.rs
@@ -28,6 +28,7 @@ fn test_app() -> (Router<()>, tempfile::TempDir) {
         firebase_project_id: "test-project".into(),
         plex_media_path: media_dir.to_string_lossy().into_owned(),
         is_dev: true,
+        dev_auth_bypass: true,
         data_dir: data_dir.to_string_lossy().into_owned(),
     };
 

--- a/trimmer/docker-compose.yml
+++ b/trimmer/docker-compose.yml
@@ -3,8 +3,7 @@ services:
     image: ghcr.io/onkr0d/titanic/trimmer:latest
     user: "0:0"
     restart: unless-stopped
-    ports:
-      - "${APP_TRIMMER_PORT:-3030}:3030"
+    # no published ports on purpose: the app has no auth; Umbrel's app_proxy provides it
     environment:
       - RUST_LOG=info
       - MEDIA_PATH=/downloads


### PR DESCRIPTION
- Redis: loopback-only bind, protected mode, optional `REDIS_PASSWORD` (fails open with a warning if unset)
- dev auth bypass now needs explicit `DEV_AUTH_BYPASS=true` in addition to `IS_DEV=true`
- Hypercorn binds loopback by default; dev/test override via `HYPERCORN_BIND`
- Umbrel app publishes 3029 on the tailnet interface only (`exports.sh` auto-detects the Tailscale IP, falls back to 0.0.0.0)
- trimmer drops its published port entirely — Umbrel's app_proxy fronts it with session auth

Compose changes for the Umbrel apps deploy via the `onkr0d/umbrel-apps` store repo (separate PR); this repo's copies are kept in sync as the source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H41Cq4Wof6gDEmpcWPDMNi