### PR TITLE
feat(trimmer): multi-audio-track trimming and preview

### DIFF
--- a/trimmer/src/lib.rs
+++ b/trimmer/src/lib.rs
@@ -174,11 +174,16 @@ const VALID_VIDEO_EXTENSIONS: &[&str] = &[
     "mp4", "avi", "mov", "mkv", "wmv", "flv", "m4v", "webm", "ts",
 ];
 
+/// Max concurrent on-demand audio extractions to keep CPU load bounded.
+pub const AUDIO_EXTRACT_CONCURRENCY: usize = 2;
+
 pub struct AppState {
     pub media_path: PathBuf,
     pub data_dir: PathBuf,
     /// In-memory cache: relative_path -> (mtime_secs, duration_secs)
     pub duration_cache: RwLock<HashMap<String, (i64, f64)>>,
+    /// Bounds concurrent /api/audio ffmpeg extractions.
+    pub audio_extract_semaphore: Semaphore,
 }
 
 #[derive(Debug, Serialize)]
@@ -209,6 +214,17 @@ pub struct PathQuery {
 }
 
 #[derive(Debug, Deserialize)]
+pub struct AudioQuery {
+    path: String,
+    track: u32,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TracksResponse {
+    tracks: Vec<trim::AudioTrack>,
+}
+
+#[derive(Debug, Deserialize)]
 pub struct VideosQuery {
     #[serde(default)]
     sort: Option<String>,
@@ -229,6 +245,8 @@ pub fn build_router(state: Arc<AppState>) -> Router<()> {
         .route("/health", get(health_check))
         .route("/api/videos", get(list_videos))
         .route("/api/video", get(serve_video))
+        .route("/api/tracks", get(list_tracks))
+        .route("/api/audio", get(serve_audio))
         .route("/api/thumbnail", get(serve_thumbnail))
         .route("/api/trim", post(handle_trim))
         .route("/api/duration", get(get_duration))
@@ -379,6 +397,45 @@ async fn serve_video(
     }
 
     Ok(ServeFile::new(&video_path)
+        .oneshot(request)
+        .await
+        .into_response())
+}
+
+async fn list_tracks(
+    State(state): State<Arc<AppState>>,
+    Query(params): Query<PathQuery>,
+) -> Result<Json<TracksResponse>, AppError> {
+    let video_path = trim::ensure_path_within(&state.media_path, Path::new(&params.path))?;
+
+    if !video_path.exists() {
+        return Err(AppError::NotFound("Video not found".into()));
+    }
+
+    let tracks = trim::list_audio_tracks(&video_path).await?;
+    Ok(Json(TracksResponse { tracks }))
+}
+
+async fn serve_audio(
+    State(state): State<Arc<AppState>>,
+    Query(params): Query<AudioQuery>,
+    request: axum::extract::Request,
+) -> Result<Response, AppError> {
+    let video_path = trim::ensure_path_within(&state.media_path, Path::new(&params.path))?;
+
+    if !video_path.exists() {
+        return Err(AppError::NotFound("Video not found".into()));
+    }
+
+    let audio_dir = state.data_dir.join("audio");
+    let _permit = state
+        .audio_extract_semaphore
+        .acquire()
+        .await
+        .map_err(|e| AppError::InternalError(format!("Semaphore closed: {e}")))?;
+    let audio_path = trim::extract_audio_track(&video_path, params.track, &audio_dir).await?;
+
+    Ok(ServeFile::new(&audio_path)
         .oneshot(request)
         .await
         .into_response())

--- a/trimmer/src/main.rs
+++ b/trimmer/src/main.rs
@@ -53,6 +53,9 @@ async fn main() -> Result<()> {
         media_path,
         data_dir,
         duration_cache: RwLock::new(HashMap::new()),
+        audio_extract_semaphore: tokio::sync::Semaphore::new(
+            trimmer::AUDIO_EXTRACT_CONCURRENCY,
+        ),
     });
 
     // Build router

--- a/trimmer/src/trim.rs
+++ b/trimmer/src/trim.rs
@@ -33,6 +33,76 @@ pub struct TrimRequest {
     pub end_time: f64,
     #[serde(default)]
     pub overwrite: bool,
+    /// Audio-relative stream indices to keep; None keeps all streams.
+    #[serde(default)]
+    pub tracks: Option<Vec<u32>>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AudioTrack {
+    pub index: u32,
+    pub title: Option<String>,
+    pub language: Option<String>,
+    pub codec: Option<String>,
+    pub default: bool,
+}
+
+/// List audio streams via ffprobe. `index` is the audio-relative index
+/// usable in `-map 0:a:{index}`.
+pub async fn list_audio_tracks(path: &Path) -> Result<Vec<AudioTrack>, AppError> {
+    let output = Command::new("ffprobe")
+        .args([
+            "-v", "error",
+            "-select_streams", "a",
+            "-show_entries",
+            "stream=codec_name:stream_tags=title,name,language:stream_disposition=default",
+            "-of", "json",
+        ])
+        .arg(path.as_os_str())
+        .output()
+        .await
+        .map_err(|e| AppError::InternalError(format!("Failed to run ffprobe: {e}")))?;
+
+    if !output.status.success() {
+        return Err(AppError::InternalError("ffprobe failed".into()));
+    }
+
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout)
+        .map_err(|e| AppError::InternalError(format!("Failed to parse ffprobe output: {e}")))?;
+
+    let streams = parsed["streams"].as_array().cloned().unwrap_or_default();
+    Ok(streams
+        .iter()
+        .enumerate()
+        .map(|(i, s)| AudioTrack {
+            index: i as u32,
+            // mp4 muxers store the stream title under "name", mkv under "title"
+            title: s["tags"]["title"]
+                .as_str()
+                .or_else(|| s["tags"]["name"].as_str())
+                .map(str::to_string),
+            language: s["tags"]["language"].as_str().map(str::to_string),
+            codec: s["codec_name"].as_str().map(str::to_string),
+            default: s["disposition"]["default"].as_i64() == Some(1),
+        })
+        .collect())
+}
+
+/// Build `-map` args for a trim. Without an explicit selection ffmpeg keeps
+/// only one audio stream, so default to `-map 0` (everything).
+fn build_map_args(tracks: Option<&[u32]>) -> Vec<String> {
+    let Some(tracks) = tracks else {
+        return vec!["-map".into(), "0".into()];
+    };
+    let mut args = vec!["-map".into(), "0:v:0".into()];
+    for t in tracks {
+        args.push("-map".into());
+        args.push(format!("0:a:{t}"));
+    }
+    // First kept track becomes default so players pick it automatically
+    args.push("-disposition:a:0".into());
+    args.push("default".into());
+    args
 }
 
 #[derive(Debug, Serialize)]
@@ -65,6 +135,43 @@ pub async fn trim_video(
         return Err(AppError::BadRequest(
             "End time must be greater than start time".into(),
         ));
+    }
+    if req.tracks.as_ref().is_some_and(|t| t.is_empty()) {
+        return Err(AppError::BadRequest(
+            "At least one audio track must be selected".into(),
+        ));
+    }
+
+    // mp4's muxer writes stream titles from the "title" key but its demuxer
+    // exposes them as "name", so a plain -c copy remux drops them; re-apply.
+    let source_tracks = match list_audio_tracks(&source).await {
+        Ok(t) => t,
+        Err(e) if req.tracks.is_some() => return Err(e),
+        Err(_) => Vec::new(),
+    };
+    let kept_tracks: Vec<&AudioTrack> = match &req.tracks {
+        Some(selection) => {
+            let kept: Vec<&AudioTrack> = selection
+                .iter()
+                .filter_map(|&i| source_tracks.get(i as usize))
+                .collect();
+            if kept.len() != selection.len() {
+                return Err(AppError::BadRequest("Invalid audio track index".into()));
+            }
+            kept
+        }
+        None => source_tracks.iter().collect(),
+    };
+    let mut metadata_args: Vec<String> = Vec::new();
+    for (out_idx, track) in kept_tracks.iter().enumerate() {
+        if let Some(title) = &track.title {
+            metadata_args.push(format!("-metadata:s:a:{out_idx}"));
+            metadata_args.push(format!("title={title}"));
+        }
+        if let Some(lang) = &track.language {
+            metadata_args.push(format!("-metadata:s:a:{out_idx}"));
+            metadata_args.push(format!("language={lang}"));
+        }
     }
 
     // Determine output path
@@ -101,6 +208,8 @@ pub async fn trim_video(
         .arg(format!("{:.3}", req.end_time))
         .arg("-i")
         .arg(source.as_os_str())
+        .args(build_map_args(req.tracks.as_deref()))
+        .args(&metadata_args)
         .arg("-c")
         .arg("copy")
         .arg("-movflags")
@@ -216,20 +325,7 @@ pub async fn generate_thumbnail(
     video_path: &Path,
     cache_dir: &Path,
 ) -> Result<PathBuf, AppError> {
-    // Create a deterministic cache filename based on path + mtime
-    let metadata = std::fs::metadata(video_path)
-        .map_err(|e| AppError::NotFound(format!("Cannot stat video: {e}")))?;
-    let mtime = metadata
-        .modified()
-        .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
-    let mtime_secs = mtime
-        .duration_since(std::time::SystemTime::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
-
-    let hash_input = format!("{}:{}", video_path.to_string_lossy(), mtime_secs);
-    let hash = simple_hash(&hash_input);
-    let thumb_path = cache_dir.join(format!("{hash}.avif"));
+    let thumb_path = cache_dir.join(cache_filename(video_path, "", "avif")?);
 
     // Return cached thumbnail if it exists
     if thumb_path.exists() {
@@ -305,6 +401,83 @@ pub async fn generate_thumbnail(
     Err(AppError::InternalError(
         "FFmpeg thumbnail generation failed".into(),
     ))
+}
+
+/// Extract a single audio track to an m4a, cached in the data directory.
+/// Stream-copies when possible, falls back to AAC for codecs mp4 can't hold.
+pub async fn extract_audio_track(
+    video_path: &Path,
+    track: u32,
+    cache_dir: &Path,
+) -> Result<PathBuf, AppError> {
+    let out_path = cache_dir.join(cache_filename(video_path, &format!(":a{track}"), "m4a")?);
+
+    if out_path.exists() {
+        return Ok(out_path);
+    }
+
+    std::fs::create_dir_all(cache_dir)
+        .map_err(|e| AppError::InternalError(format!("Failed to create audio cache: {e}")))?;
+
+    // Extract to a per-call temp file and atomically rename into place, so
+    // concurrent requests for the same track never write or serve a partial file.
+    let unique = format!(
+        "{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::SystemTime::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos()
+    );
+    let tmp_path = cache_dir.join(format!(".{unique}.tmp.m4a"));
+
+    let codec_attempts: [&[&str]; 2] = [&["-c:a", "copy"], &["-c:a", "aac", "-b:a", "192k"]];
+    for codec_args in codec_attempts {
+        let status = Command::new("ffmpeg")
+            .args(["-y", "-i"])
+            .arg(video_path.as_os_str())
+            .arg("-map")
+            .arg(format!("0:a:{track}"))
+            .arg("-vn")
+            .args(codec_args)
+            .args(["-movflags", "+faststart"])
+            .arg(tmp_path.as_os_str())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .kill_on_drop(true) // don't leave orphaned ffmpeg when the request is canceled
+            .status()
+            .await;
+
+        if let Ok(s) = status
+            && s.success()
+            && tmp_path.exists()
+            && std::fs::rename(&tmp_path, &out_path).is_ok()
+        {
+            info!("Extracted audio track {} from {:?}", track, video_path);
+            return Ok(out_path);
+        }
+        let _ = std::fs::remove_file(&tmp_path);
+    }
+
+    Err(AppError::InternalError(format!(
+        "Failed to extract audio track {track}"
+    )))
+}
+
+/// Deterministic cache filename from a source file's path + mtime, plus an
+/// `extra` discriminator (e.g. an audio track index). Keyed on mtime so the
+/// entry naturally invalidates when the source file changes.
+fn cache_filename(source: &Path, extra: &str, ext: &str) -> Result<String, AppError> {
+    let metadata = std::fs::metadata(source)
+        .map_err(|e| AppError::NotFound(format!("Cannot stat file: {e}")))?;
+    let mtime_secs = metadata
+        .modified()
+        .unwrap_or(std::time::SystemTime::UNIX_EPOCH)
+        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let hash_input = format!("{}:{}{}", source.to_string_lossy(), mtime_secs, extra);
+    Ok(format!("{}.{ext}", simple_hash(&hash_input)))
 }
 
 /// Simple hash for cache filenames (not cryptographic, just for deduplication).
@@ -398,5 +571,190 @@ mod tests {
         let b = simple_hash("test");
         assert_eq!(a, b);
         assert_ne!(a, simple_hash("other"));
+    }
+
+    #[test]
+    fn map_args_default_keeps_everything() {
+        assert_eq!(build_map_args(None), vec!["-map", "0"]);
+    }
+
+    #[test]
+    fn map_args_selected_tracks() {
+        assert_eq!(
+            build_map_args(Some(&[0, 2])),
+            vec![
+                "-map",
+                "0:v:0",
+                "-map",
+                "0:a:0",
+                "-map",
+                "0:a:2",
+                "-disposition:a:0",
+                "default"
+            ]
+        );
+    }
+
+    /// Create a test video with 3 stereo audio tracks (like pipeline output).
+    async fn make_multitrack_video(path: &Path) -> bool {
+        let status = tokio::process::Command::new("ffmpeg")
+            .args([
+                "-y",
+                "-f", "lavfi", "-i", "testsrc=duration=2:size=128x72:rate=10",
+                "-f", "lavfi", "-i", "sine=frequency=440:duration=2",
+                "-f", "lavfi", "-i", "sine=frequency=880:duration=2",
+                "-f", "lavfi", "-i", "sine=frequency=1320:duration=2",
+                "-map", "0:v", "-map", "1:a", "-map", "2:a", "-map", "3:a",
+                "-c:v", "mpeg4", "-c:a", "aac",
+                "-metadata:s:a:0", "title=Default mix",
+                "-metadata:s:a:1", "title=System only (raw)",
+                "-metadata:s:a:2", "title=Mic only (raw)",
+                "-disposition:a:0", "default",
+            ])
+            .arg(path.as_os_str())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .await;
+        matches!(status, Ok(s) if s.success())
+    }
+
+    fn ffmpeg_available() -> bool {
+        std::process::Command::new("ffmpeg")
+            .arg("-version")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .is_ok()
+    }
+
+    #[tokio::test]
+    async fn trim_keeps_all_audio_tracks() {
+        if !ffmpeg_available() {
+            eprintln!("ffmpeg not available, skipping");
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("multi.mp4");
+        assert!(make_multitrack_video(&source).await);
+
+        let req = TrimRequest {
+            path: "multi.mp4".into(),
+            start_time: 0.0,
+            end_time: 1.0,
+            overwrite: false,
+            tracks: None,
+        };
+        let res = trim_video(dir.path(), &req).await.unwrap();
+
+        let tracks = list_audio_tracks(&dir.path().join(&res.output_path))
+            .await
+            .unwrap();
+        assert_eq!(tracks.len(), 3);
+        assert_eq!(tracks[0].title.as_deref(), Some("Default mix"));
+        assert!(tracks[0].default);
+        assert_eq!(tracks[2].title.as_deref(), Some("Mic only (raw)"));
+    }
+
+    #[tokio::test]
+    async fn trim_keeps_selected_tracks_and_sets_default() {
+        if !ffmpeg_available() {
+            eprintln!("ffmpeg not available, skipping");
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("multi.mp4");
+        assert!(make_multitrack_video(&source).await);
+
+        let req = TrimRequest {
+            path: "multi.mp4".into(),
+            start_time: 0.0,
+            end_time: 1.0,
+            overwrite: false,
+            tracks: Some(vec![1, 2]),
+        };
+        let res = trim_video(dir.path(), &req).await.unwrap();
+
+        let tracks = list_audio_tracks(&dir.path().join(&res.output_path))
+            .await
+            .unwrap();
+        assert_eq!(tracks.len(), 2);
+        assert_eq!(tracks[0].title.as_deref(), Some("System only (raw)"));
+        assert!(tracks[0].default);
+        assert!(!tracks[1].default);
+    }
+
+    #[tokio::test]
+    async fn extract_track_cached() {
+        if !ffmpeg_available() {
+            eprintln!("ffmpeg not available, skipping");
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("multi.mp4");
+        assert!(make_multitrack_video(&source).await);
+
+        let cache = dir.path().join("audio-cache");
+        let first = extract_audio_track(&source, 1, &cache).await.unwrap();
+        assert!(first.exists());
+        let mtime = std::fs::metadata(&first).unwrap().modified().unwrap();
+
+        // Second call must hit the cache, not re-extract
+        let second = extract_audio_track(&source, 1, &cache).await.unwrap();
+        assert_eq!(first, second);
+        assert_eq!(std::fs::metadata(&second).unwrap().modified().unwrap(), mtime);
+    }
+
+    #[tokio::test]
+    async fn concurrent_extract_same_track_yields_valid_files() {
+        if !ffmpeg_available() {
+            eprintln!("ffmpeg not available, skipping");
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("multi.mp4");
+        assert!(make_multitrack_video(&source).await);
+        let cache = dir.path().join("audio-cache");
+
+        // Race several extractions of the same track; atomic publish must ensure
+        // every returned path is a fully-muxed, probeable file (no partial serve).
+        let handles: Vec<_> = (0..6)
+            .map(|_| {
+                let src = source.clone();
+                let cache = cache.clone();
+                tokio::spawn(async move { extract_audio_track(&src, 1, &cache).await })
+            })
+            .collect();
+
+        for h in handles {
+            let path = h.await.unwrap().unwrap();
+            assert!(path.exists());
+            // A partial/corrupt m4a would have no probeable audio stream.
+            let tracks = list_audio_tracks(&path).await.unwrap();
+            assert_eq!(tracks.len(), 1);
+        }
+        // Only the final cache file should remain — no leftover temp files.
+        let leftovers: Vec<_> = std::fs::read_dir(&cache)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().contains(".tmp."))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
+
+    #[tokio::test]
+    async fn empty_track_selection_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("video.mp4");
+        std::fs::write(&source, b"test").unwrap();
+
+        let req = TrimRequest {
+            path: "video.mp4".into(),
+            start_time: 0.0,
+            end_time: 1.0,
+            overwrite: false,
+            tracks: Some(vec![]),
+        };
+        assert!(trim_video(dir.path(), &req).await.is_err());
     }
 }

--- a/trimmer/static/app.js
+++ b/trimmer/static/app.js
@@ -12,6 +12,10 @@
     let trimStart = 0;
     let trimEnd = 0;
     let pausedAtTrimEnd = false;
+    let audioTracks = [];
+    let previewAudio = null; // synced <audio> element when previewing a non-default track
+    let previewTrackIndex = 0; // which audio track is currently being previewed
+    let audioMuted = false; // user's mute preference, persisted across track switches
 
     // ---- DOM refs ----
     const $ = (sel) => document.querySelector(sel);
@@ -37,6 +41,10 @@
     const confirmModal = $('#confirmModal');
     const confirmCancel = $('#confirmCancel');
     const confirmProceed = $('#confirmProceed');
+    const audioTrackRow = $('#audioTrackRow');
+    const audioTrackDropdown = $('#audioTrackDropdown');
+    const trackKeepSection = $('#trackKeepSection');
+    const trackKeepList = $('#trackKeepList');
 
     // Custom video controls
     const playerContainer = $('#playerContainer');
@@ -137,15 +145,28 @@
         return data.duration;
     }
 
-    async function requestTrim(path, startTime, endTime, overwrite) {
+    async function requestTrim(path, startTime, endTime, overwrite, tracks) {
+        const body = { path, startTime, endTime, overwrite };
+        if (tracks) body.tracks = tracks;
         const res = await fetch('/api/trim', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ path, startTime, endTime, overwrite }),
+            body: JSON.stringify(body),
         });
         const data = await res.json();
         if (!res.ok) throw new Error(data.error || 'Trim failed');
         return data;
+    }
+
+    async function fetchAudioTracks(path) {
+        try {
+            const res = await fetch(`/api/tracks?path=${encodeURIComponent(path)}`);
+            if (!res.ok) return [];
+            const data = await res.json();
+            return data.tracks || [];
+        } catch {
+            return [];
+        }
     }
 
     // ---- Rendering ----
@@ -251,17 +272,130 @@
 
         videoMeta.textContent = `${formatSize(video.size)} · ${video.folder || 'Clips'}`;
         overwriteToggle.checked = false;
+
+        clearPreviewAudio();
+        audioTracks = await fetchAudioTracks(video.path);
+        renderAudioTrackUi();
     }
 
     function closeEditor() {
         editorView.style.display = 'none';
         libraryView.style.display = '';
         backBtn.style.display = 'none';
+        clearPreviewAudio();
         videoPlayer.pause();
         videoPlayer.src = '';
         currentVideo = null;
         // Reload in case new files were created
         loadVideos();
+    }
+
+    // ---- Audio tracks ----
+    function trackShortLabel(track, i) {
+        // "Default mix (system + mic, EBU R128)" -> "Default mix"
+        if (track.title) return track.title.split('(')[0].trim();
+        return `Track ${i + 1}`;
+    }
+
+    function renderAudioTrackUi() {
+        const multi = audioTracks.length > 1;
+        audioTrackRow.style.display = multi ? '' : 'none';
+        trackKeepSection.style.display = multi ? '' : 'none';
+        if (!multi) return;
+
+        const menu = audioTrackDropdown.querySelector('.custom-select-menu');
+        menu.innerHTML = '';
+        audioTracks.forEach((t, i) => {
+            const opt = document.createElement('li');
+            opt.className = 'custom-select-option' + (i === 0 ? ' selected' : '');
+            opt.dataset.value = String(i);
+            opt.textContent = trackShortLabel(t, i);
+            if (t.title) opt.title = t.title;
+            menu.appendChild(opt);
+        });
+        audioTrackDropdown.querySelector('.custom-select-value').textContent =
+            trackShortLabel(audioTracks[0], 0);
+
+        trackKeepList.innerHTML = '';
+        audioTracks.forEach((t, i) => {
+            const label = document.createElement('label');
+            label.className = 'track-keep-item';
+            const cb = document.createElement('input');
+            cb.type = 'checkbox';
+            cb.checked = true;
+            cb.dataset.track = String(i);
+            const text = document.createElement('span');
+            text.textContent = t.title || trackShortLabel(t, i);
+            label.appendChild(cb);
+            label.appendChild(text);
+            trackKeepList.appendChild(label);
+        });
+    }
+
+    // The element currently producing sound: the video itself (default track)
+    // or the synced <audio> element (alternate track).
+    function audioSink() {
+        return previewAudio || videoPlayer;
+    }
+
+    function clearPreviewAudio() {
+        if (previewAudio) {
+            previewAudio.pause();
+            previewAudio.removeAttribute('src');
+            previewAudio = null;
+        }
+        previewTrackIndex = 0;
+        videoPlayer.volume = parseFloat(volumeSlider.value);
+        videoPlayer.muted = audioMuted;
+        syncMuteIcon();
+    }
+
+    function setPreviewTrack(index) {
+        if (index === previewTrackIndex) return; // already previewing this track
+        clearPreviewAudio();
+        if (index === 0 || !currentVideo) return;
+        previewTrackIndex = index;
+
+        previewAudio = new Audio(
+            `/api/audio?path=${encodeURIComponent(currentVideo.path)}&track=${index}`
+        );
+        previewAudio.preload = 'auto';
+        previewAudio.volume = parseFloat(volumeSlider.value);
+        previewAudio.muted = audioMuted; // carry the user's mute onto the new sink
+        // If extraction fails, fall back to the video's own audio instead of
+        // leaving playback silent with the video muted.
+        previewAudio.addEventListener('error', () => onPreviewAudioError(index));
+        videoPlayer.muted = true; // alternate track plays via previewAudio, not the video
+
+        // Seek to the video's position only once the audio can honor it; setting
+        // currentTime on a not-yet-loaded element is dropped and would start at 0.
+        const syncWhenReady = () => {
+            if (previewTrackIndex !== index || !previewAudio) return;
+            previewAudio.currentTime = videoPlayer.currentTime;
+            if (!videoPlayer.paused) playPreview(index);
+        };
+        if (previewAudio.readyState >= 1) syncWhenReady();
+        else previewAudio.addEventListener('loadedmetadata', syncWhenReady, { once: true });
+
+        syncMuteIcon();
+    }
+
+    function playPreview(index) {
+        if (!previewAudio) return;
+        previewAudio.play().catch((e) => {
+            // Ignore autoplay-policy rejections; surface real failures.
+            if (e && e.name !== 'NotAllowedError' && e.name !== 'AbortError') {
+                onPreviewAudioError(index);
+            }
+        });
+    }
+
+    function onPreviewAudioError(index) {
+        // Guard against stale handlers firing after the user moved on.
+        if (previewTrackIndex !== index) return;
+        clearPreviewAudio();
+        setDropdownValue(audioTrackDropdown, '0');
+        showToast('Could not load that audio track; playing default mix', 'error');
     }
 
     // ---- Timeline / Sliders ----
@@ -316,6 +450,12 @@
             pausedAtTrimEnd = true;
             videoPlayer.pause();
         }
+
+        // Correct alternate-track drift
+        if (previewAudio && !videoPlayer.paused
+            && Math.abs(previewAudio.currentTime - videoPlayer.currentTime) > 0.2) {
+            previewAudio.currentTime = videoPlayer.currentTime;
+        }
     }
 
     function updateBuffered() {
@@ -339,7 +479,8 @@
     function syncMuteIcon() {
         const onIcon = muteBtn.querySelector('.vol-on-icon');
         const offIcon = muteBtn.querySelector('.vol-off-icon');
-        if (videoPlayer.muted || videoPlayer.volume === 0) {
+        const sink = audioSink();
+        if (sink.muted || sink.volume === 0) {
             onIcon.style.display = 'none';
             offIcon.style.display = '';
         } else {
@@ -374,6 +515,7 @@
         searchInput.addEventListener('input', renderLibrary);
         initDropdown(folderDropdown, () => loadVideos());
         initDropdown(sortDropdown, () => loadVideos());
+        initDropdown(audioTrackDropdown, (v) => setPreviewTrack(parseInt(v, 10)));
 
         // ---- Custom video controls ----
         // Play/pause button
@@ -416,20 +558,51 @@
         });
 
         document.addEventListener('mouseup', () => {
+            if (!isSeeking) return;
             isSeeking = false;
+            // Resync the alternate audio once at the drop point, not on every
+            // intermediate seek during the drag.
+            if (previewAudio) previewAudio.currentTime = videoPlayer.currentTime;
         });
 
-        // Volume
+        // Volume (applies to whichever element is producing sound)
         volumeSlider.addEventListener('input', () => {
-            videoPlayer.volume = parseFloat(volumeSlider.value);
-            videoPlayer.muted = false;
+            const sink = audioSink();
+            sink.volume = parseFloat(volumeSlider.value);
+            audioMuted = false;
+            sink.muted = false;
             syncMuteIcon();
         });
 
         muteBtn.addEventListener('click', (e) => {
             e.stopPropagation();
-            videoPlayer.muted = !videoPlayer.muted;
+            audioMuted = !audioMuted;
+            audioSink().muted = audioMuted;
             syncMuteIcon();
+        });
+
+        // Keep alternate audio track in lockstep with the video
+        videoPlayer.addEventListener('play', () => {
+            if (!previewAudio) return;
+            previewAudio.currentTime = videoPlayer.currentTime;
+            previewAudio.play().catch(() => {});
+        });
+        videoPlayer.addEventListener('pause', () => {
+            if (previewAudio) previewAudio.pause();
+        });
+        videoPlayer.addEventListener('seeked', () => {
+            // Skip during an active scrub-drag; mouseup does the single resync.
+            if (previewAudio && !isSeeking) previewAudio.currentTime = videoPlayer.currentTime;
+        });
+        // The video freezes while buffering without firing 'pause', so hold the
+        // audio during a stall and resync when playback actually resumes.
+        videoPlayer.addEventListener('waiting', () => {
+            if (previewAudio) previewAudio.pause();
+        });
+        videoPlayer.addEventListener('playing', () => {
+            if (!previewAudio || videoPlayer.paused) return;
+            previewAudio.currentTime = videoPlayer.currentTime;
+            previewAudio.play().catch(() => {});
         });
 
         // Fullscreen
@@ -585,7 +758,21 @@
         executeTrim(false);
     }
 
+    function selectedTracks() {
+        // null = keep everything (server default); array = explicit selection
+        if (audioTracks.length <= 1) return null;
+        const checked = [...trackKeepList.querySelectorAll('input:checked')]
+            .map((cb) => parseInt(cb.dataset.track, 10));
+        return checked.length === audioTracks.length ? null : checked;
+    }
+
     async function executeTrim(overwrite) {
+        const tracks = selectedTracks();
+        if (tracks && tracks.length === 0) {
+            showToast('Select at least one audio track to keep', 'error');
+            return;
+        }
+
         trimBtn.disabled = true;
         trimBtn.innerHTML = '<span class="spinner" style="width:18px;height:18px;border-width:2px;margin:0"></span> Trimming...';
 
@@ -594,7 +781,8 @@
                 currentVideo.path,
                 trimStart,
                 trimEnd,
-                overwrite
+                overwrite,
+                tracks
             );
             showToast(result.message, 'success');
         } catch (err) {

--- a/trimmer/static/index.html
+++ b/trimmer/static/index.html
@@ -8,7 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/static/style.css?v=2">
+    <link rel="stylesheet" href="/static/style.css?v=3">
     <!-- Prevent iOS standalone (Add to Home Screen) from aggressively caching -->
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <meta http-equiv="Pragma" content="no-cache">
@@ -110,6 +110,16 @@
                     <div class="video-info">
                         <h2 id="videoTitle" class="video-title"></h2>
                         <p id="videoMeta" class="video-meta"></p>
+                        <div class="audio-track-row" id="audioTrackRow" style="display:none;">
+                            <span class="audio-track-label">🎧 Preview audio</span>
+                            <div class="custom-select" id="audioTrackDropdown">
+                                <button class="custom-select-trigger" type="button">
+                                    <span class="custom-select-value">Default</span>
+                                    <svg class="custom-select-chevron" viewBox="0 0 24 24" width="16" height="16"><path d="M7 10l5 5 5-5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                                </button>
+                                <ul class="custom-select-menu"></ul>
+                            </div>
+                        </div>
                     </div>
                 </div>
 
@@ -139,6 +149,11 @@
                                 <label for="endTimeInput">End</label>
                                 <input type="text" id="endTimeInput" class="time-input" value="0:00.000" placeholder="0:00.000">
                             </div>
+                        </div>
+
+                        <div class="track-keep" id="trackKeepSection" style="display:none;">
+                            <h4>Audio tracks to keep</h4>
+                            <div id="trackKeepList" class="track-keep-list"></div>
                         </div>
 
                         <div class="trim-actions">
@@ -188,6 +203,6 @@
         <div id="toastContainer" class="toast-container"></div>
     </div>
 
-    <script src="/static/app.js?v=2"></script>
+    <script src="/static/app.js?v=5"></script>
 </body>
 </html>

--- a/trimmer/static/style.css
+++ b/trimmer/static/style.css
@@ -1070,3 +1070,53 @@ body {
         flex-wrap: wrap;
     }
 }
+
+/* ---------- Audio Tracks ---------- */
+.audio-track-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-top: 10px;
+}
+
+.audio-track-label {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    font-weight: 500;
+}
+
+.track-keep {
+    margin-bottom: 20px;
+}
+
+.track-keep h4 {
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--text-tertiary);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    margin-bottom: 10px;
+}
+
+.track-keep-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.track-keep-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    cursor: pointer;
+    user-select: none;
+}
+
+.track-keep-item input {
+    accent-color: var(--accent);
+    width: 16px;
+    height: 16px;
+    cursor: pointer;
+}


### PR DESCRIPTION
## What

The trimmer now handles the pipeline's 3 audio tracks instead of collapsing them to the mixed track.

- **Keep all tracks by default.** The old trim ran `ffmpeg -c copy` with no `-map`, so ffmpeg kept only the first audio stream (the mix) and dropped system + mic. Trims now map every track by default, or an explicit per-track subset via checkboxes.
- **Track titles survive.** mp4's muxer writes stream titles under `title` but its demuxer reads them as `name`, so a plain `-c copy` remux loses them; they're now re-applied.
- **Preview any track.** A dropdown extracts a chosen track to a cached m4a (`/api/audio`) and plays it as a synced `<audio>` element over the muted video; `/api/tracks` lists the streams.

## Notes

- `extract_audio_track` publishes atomically (temp + rename) with `kill_on_drop`, and extraction is bounded by a semaphore, so concurrent/cancelled requests can't corrupt the cache or orphan ffmpeg.
- Preview sync handles a failed extraction (falls back to the video's own audio), persistent mute, scrub-drag, buffering stalls, and mid-playback switches.
- Thumbnail and audio caches share one `cache_filename` helper (hashes unchanged, existing caches stay valid).

## Test

21 tests pass, including a concurrency regression test for the atomic cache publish. Verified end-to-end in the browser (switching, selective trim, mute persistence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)